### PR TITLE
update vim-better-whitespace_conf.lua

### DIFF
--- a/nvim/.config/nvim/lua/vim-better-whitespace_conf.lua
+++ b/nvim/.config/nvim/lua/vim-better-whitespace_conf.lua
@@ -1,4 +1,4 @@
-vim.g.better_whitespace_filetypes_blacklist = "['dashboard']"
+vim.g.better_whitespace_filetypes_blacklist = {'dashboard'}
 vim.cmd [[ highlight ExtraWhitespace ctermbg=78 ]]
 vim.keymap.set('n', '<leader>pw', '<cmd>StripWhitespace<CR>', { noremap = true, desc = 'Strip whitespace' })
 vim.keymap.set('n', '<leader>pW', '<cmd>ToggleWhitespace<CR>', { noremap = true, desc = 'Toggle whitespace' })


### PR DESCRIPTION
better_whitespace_filetypes_blacklist supposed to be an array/list, not a string

Avoid error like 

~~~
Error detected while processing function <SNR>50_ToggleWhitespace[1]..<SNR>50_ShouldHighlight:                                         
line    3:  
E897: List or Blob required
~~~